### PR TITLE
Docker can now be used for development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,11 @@ version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
       - image: circleci/php:7.2-node-browsers
     working_directory: ~/theme
     steps:
       - checkout
       # Download and cache dependencies
-      - run:
-          name: Setup environment
-          command: |
-            echo $DEV_GITHUB_KEY > ~/.ssh/dev_github_key
-            chmod 400 ~/.ssh/dev_github_key
-            ssh-add ~/.ssh/dev_github_key
       - run:
           name: Install redandblue CLI
           command: sudo npm install -g yo @redandblue/generator-redandblue
@@ -45,9 +38,32 @@ jobs:
       - run:
           name: Run PHP unit tests
           command: ./vendor/bin/phpunit --bootstrap vendor/autoload.php tests/ExampleTest
+
+  deploy:
+    docker:
+      - image: circleci/php:7.2-node-browsers
+    environment:
+      GOOGLE_PROJECT_ID: duodecim-203606
+      GOOGLE_COMPUTE_ZONE: europe-west4-a
+    steps:
+      - checkout
+      - run:
+          name: Build Docker image
+          command: |
+            gcloud auth configure-docker
+            docker build -t redandblue/duodecim-ebmeds .
+          #  docker push eu.gcr.io/${GOOGLE_PROJECT_ID}/duodecim-theme
+
 workflows:
   version: 2
   build-deploy:
     jobs:
       - build:
           context: redandblue
+      - deploy:
+          context: redandblue
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
     docker:
       - image: circleci/php:7.2-node-browsers
     environment:
-      GOOGLE_PROJECT_ID: duodecim-203606
+      GOOGLE_PROJECT_ID: PROJECT_ID_HERE
       GOOGLE_COMPUTE_ZONE: europe-west4-a
     steps:
       - checkout
@@ -51,8 +51,8 @@ jobs:
           name: Build Docker image
           command: |
             gcloud auth configure-docker
-            docker build -t redandblue/duodecim-ebmeds .
-          #  docker push eu.gcr.io/${GOOGLE_PROJECT_ID}/duodecim-theme
+            docker build -t redandblue/theme-skeletor .
+          #  docker push eu.gcr.io/${GOOGLE_PROJECT_ID}/theme-skeletor
 
 workflows:
   version: 2
@@ -60,10 +60,10 @@ workflows:
     jobs:
       - build:
           context: redandblue
-      - deploy:
-          context: redandblue
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
+      # - deploy:
+      #     context: redandblue
+      #     requires:
+      #       - build
+      #     filters:
+      #       branches:
+      #         only: master

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 nginx/
 scripts/
 
+.env
 composer.json
 config-sample.yml
 LICENSE

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,9 @@ htdocs/*
 htdocs/wp-content/*
 !htdocs/wp-content/themes/
 
-# Vagrant run-time output, not need to track in git
-bin
+# Run-time output, not need to track in git
+tmp/
+bin/
 .vagrant
 mkmf.log
 myrecording

--- a/Deploying.md
+++ b/Deploying.md
@@ -1,0 +1,49 @@
+# How to roll with Docker
+
+## Locally (or CI)
+
+1.  Make sure the project runs on your local (= everything compiled, etc)
+2.  Make sure you're on right project: `gcloud config set project duodecim-203606`
+3.  Modify one file to correct path:
+    * Modify: htdocs/wp-content/themes/duodecim-theme/includes/enqueue.php
+    * Modify `WPT_ENQUEUE_STRIP_PATH` to `/var/www/html`
+4.  Authenticate Docker with Google Cloud: `gcloud auth configure-docker`
+5.  Build the Docker image: `docker build -t redandblue/duodecim-ebmeds .`
+6.  Tag the image for Google Cloud: `docker tag [SOURCE_IMAGE] [HOSTNAME]/[PROJECT-ID]/[IMAGE]`
+    * e.g. `docker tag redandblue/duodecim-ebmeds eu.gcr.io/duodecim-203606/duodecim-ebmeds`
+7.  Push the image to Google Cloud Registry `docker push [HOSTNAME]/[PROJECT-ID]/[IMAGE]`
+    * e.g. `docker push eu.gcr.io/duodecim-203606/duodecim-ebmeds`
+
+---
+
+## On server
+
+1.  `google auth configure-docker` (if not done yet)
+    * Sometimes it says it works, but image pull still fails
+    * If that happens, try: `gcloud docker -a`
+2.  `[sudo] docker pull eu.gcr.io/duodecim-203606/duodecim-ebmedss` should now work
+3.  Start the whole thing with: `[sudo] docker-compose up -d`
+
+# How to use Docker
+
+## Access WP-CLI with:
+
+`docker-compose run --rm wp-cli`
+
+Recommend doing this: alias wpd='docker-compose run --rm wp-cli'
+Then use it with 'wpd' as you would normally with 'wp', e.g. "wpd user list"
+
+## First time setup
+
+* wpd core install --url=http://duodecim.local:8080 --title=Duodecim --admin_email=admin@duodecim.local --admin_user=vagrant --admin_password=vagrant
+* wpd core is-installed
+* wpd plugin activate --all
+
+## Access bash inside Docker
+
+`docker exec -it $(docker ps --format "{{.ID}}" --filter="name=wordpress_1") sh`
+That will open you terminal inside the Wordpress image
+
+## Shutdown, remove everything and then restart:
+
+`docker-compose down --volumes && rm -rf tmp/ && docker-compose rm -sf && docker-compose up`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM wordpress:4.9.5-php7.2-apache
+
+## Copy our customer-specific things to the Docker image
+## TODO This is still pretty sloppy (e.g. we don't need to include code, only compiled)
+COPY htdocs/wp-content/themes/theme-skeletor /var/www/html/wp-content/themes/theme-skeletor
+COPY htdocs/wp-content/mu-plugins /var/www/html/wp-content/mu-plugins
+COPY htdocs/wp-content/plugins /var/www/html/wp-content/plugins

--- a/README.md
+++ b/README.md
@@ -2,53 +2,42 @@
 
 This is _the_ starter kit for creating new customer-specific WordPress setups.
 
+This is stand-alone package for the customer's project. It requires base project (e.g. plain WordPress or Skeletor) in order to run.
+
 # Getting started
 
+There's now 2 ways to run with this project.
+1. New, more lightweight approach with Docker 🐳
+2. Old, slightly heavier way with our old, magnificent Skeletor 🙊
+
+Choose your flavour (also depending on project), instructions below.
+
+## Option 1) with Docker
+
+1. Edit `/etc/hosts` and add your preferred hostname
+    * e.g. `127.0.0.0    theme-skeletor.local`
+2. Run `echo "DB_PASSWORD=example123" > .env`
+2. Run `docker-compose up`
+3. Access your new WordPress at `http://theme-skeletor.local:8080`
+
+> You need to have Docker installed
+
+## Option 2) with Vagrant [Deprecated]
+
+This method still works, but we'll deprecate this method soon.
+Lightweight approach with Docker is more versatile and works in all environments,
+so it's no Seravo-specific as Skeletor is.
+a
 1.  Install our CLI: `[sudo] npm install -g yo generator-redandblue`
 2.  Kickstart the project: `yo redandblue:wordpress`
+3.  Yeoman is a nice guy and will guide you through the rest of the setup
 
-## Development
+> You need to have Node.js 8+, NPM, Vagrant, Composer, etc. installed
 
-Modify `htdocs/wp-content/themes/theme-skeletor/config.json` and set the site URL for Browsersync. Use the same URL you're using for Vagrant.
+# Where to go next?
 
-Install development dependencies by running `npm install`.
+Next you'll probably want to start writing code. Check out
+`docs/Development.md` for some tips how to get started with that.
 
-Finally run `npm run dev` to run build and Browsersync. The browser tab doesn't open automatically so just head to the `https://localhost:3000`. If you have something running on 3000, it will automatically try the next port, such as 3001.
-
-# Webfonts
-
-Webfonts are a bit tricky. `@font-face` works, but a bit different than you might expect. Basically, you're going to want to put your declarations to `app/styl/typography.styl`, and your fonts in `app/fonts/`, but you're going to refer to them as if they were in `app/styl/fonts`:
-
-```
-@font-face {
-  font-family: 'FontName';
-  src: url('./fonts/FontName/weight.woff')
-    format('woff');
-  font-weight: 700;
-}
-```
-
-# Deploying
-
-This is stand-alone package for the customer's project. It requires base project (e.g. Skeletor) in order to run, and it can be managed with redandblue Yeoman generator.
-
-## Deploying with Docker
-
-See `Deplying.md`
-
-## Tagging
-
-Composer won't use the master branch. Instead it uses tags. When you have something you want to deploy, commit your changes, and then run `git tag [your-version-here]`. If you are unsure what version number to use for the tag, run `git tag` to see a list of tags. Semantic versioning is just about the only versioning that makes sense, so use that. Basics of semantic versioning: **major**.**minor**.**patch**
-
-Increment the _major_ number if you introduce breaking changes. Doesn't really happen in themes.
-Increment the _minor_ number if you add features.
-Increment the _patch_ number if you fix bugs.
-
-So if the current version is 0.3.1, and you add a new feature, run `git tag 0.4`.
-To make the tag available for Composer, run `git push origin 0.4`.
-
-Then when you run `composer update` on projects that have required this theme, you should see output similar to this:
-
-```
-- Updating redandblue/theme-skeleton (0.1 => 0.1.1):  Checking out 7e4615cfd8
-```
+Once you're done with your code, checkout the `docs/Deployment.md` on
+how to get your code running on other environments than your local machine.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Choose your flavour (also depending on project), instructions below.
 
 ## Option 1) with Docker
 
-1. Edit `/etc/hosts` and add your preferred hostname
+1. Clone this project
+2. Edit `/etc/hosts` and add your preferred hostname
     * e.g. `127.0.0.0    theme-skeletor.local`
-2. Run `echo "DB_PASSWORD=example123" > .env`
-2. Run `docker-compose up`
-3. Access your new WordPress at `http://theme-skeletor.local:8080`
+3. Run `echo "DB_PASSWORD=example123" > .env`
+4. Run `docker-compose up`
+5. Access your new WordPress at `http://theme-skeletor.local:8080`
 
 > You need to have Docker installed
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This is _the_ starter kit for creating new customer-specific WordPress setups.
 
 # Getting started
 
-1. Install our CLI: `[sudo] npm install -g yo generator-redandblue`
-2. Kickstart the project: `yo redandblue:wordpress`
+1.  Install our CLI: `[sudo] npm install -g yo generator-redandblue`
+2.  Kickstart the project: `yo redandblue:wordpress`
 
 ## Development
 
@@ -16,7 +16,9 @@ Install development dependencies by running `npm install`.
 Finally run `npm run dev` to run build and Browsersync. The browser tab doesn't open automatically so just head to the `https://localhost:3000`. If you have something running on 3000, it will automatically try the next port, such as 3001.
 
 # Webfonts
+
 Webfonts are a bit tricky. `@font-face` works, but a bit different than you might expect. Basically, you're going to want to put your declarations to `app/styl/typography.styl`, and your fonts in `app/fonts/`, but you're going to refer to them as if they were in `app/styl/fonts`:
+
 ```
 @font-face {
   font-family: 'FontName';
@@ -27,19 +29,26 @@ Webfonts are a bit tricky. `@font-face` works, but a bit different than you migh
 ```
 
 # Deploying
+
 This is stand-alone package for the customer's project. It requires base project (e.g. Skeletor) in order to run, and it can be managed with redandblue Yeoman generator.
 
+## Deploying with Docker
+
+See `Deplying.md`
+
 ## Tagging
+
 Composer won't use the master branch. Instead it uses tags. When you have something you want to deploy, commit your changes, and then run `git tag [your-version-here]`. If you are unsure what version number to use for the tag, run `git tag` to see a list of tags. Semantic versioning is just about the only versioning that makes sense, so use that. Basics of semantic versioning: **major**.**minor**.**patch**
 
-Increment the *major* number if you introduce breaking changes. Doesn't really happen in themes.
-Increment the *minor* number if you add features.
-Increment the *patch* number if you fix bugs.
+Increment the _major_ number if you introduce breaking changes. Doesn't really happen in themes.
+Increment the _minor_ number if you add features.
+Increment the _patch_ number if you fix bugs.
 
 So if the current version is 0.3.1, and you add a new feature, run `git tag 0.4`.
 To make the tag available for Composer, run `git push origin 0.4`.
 
 Then when you run `composer update` on projects that have required this theme, you should see output similar to this:
+
 ```
 - Updating redandblue/theme-skeleton (0.1 => 0.1.1):  Checking out 7e4615cfd8
 ```

--- a/customer.json
+++ b/customer.json
@@ -1,4 +1,0 @@
-{
-  "require": {},
-  "require-dev": {}
-}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,16 +13,14 @@ services:
   wordpress:
     depends_on:
       - mysql
-    image: wordpress:4.9.5-php7.2-apache
+    image: redandblue/theme-skeletor:latest
     restart: always
     ports:
       - 8080:80
     environment:
       WORDPRESS_DB_PASSWORD: ${DB_PASSWORD}
     volumes:
-      - ./htdocs/wp-content/themes/theme-skeletor:/var/www/html/wp-content/themes/theme-skeletor
-      - ./htdocs/wp-content/mu-plugins:/var/www/html/wp-content/mu-plugins
-      - ./htdocs/wp-content/plugins:/var/www/html/wp-content/plugins
+      - wordpress:/var/www/html
 
   wp-cli:
     depends_on:
@@ -31,7 +29,7 @@ services:
     environment:
       WORDPRESS_DB_PASSWORD: ${DB_PASSWORD}
     volumes:
-      - ./htdocs:/var/www/html
+      - wordpress:/var/www/html
 
 volumes:
   wordpress:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.3'
+
+services:
+
+  mysql:
+    image: mysql:5.7
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+    volumes:
+      - ./tmp/mysql:/var/lib/mysql
+
+  wordpress:
+    depends_on:
+      - mysql
+    image: redandblue/theme-skeletor:latest
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_PASSWORD: example
+    volumes:
+      - wordpress:/var/www/html
+
+  wp-cli:
+    depends_on:
+      - wordpress
+    image: wordpress:cli
+    environment:
+      WORDPRESS_DB_PASSWORD: example
+    volumes:
+      - wordpress:/var/www/html
+
+volumes:
+  wordpress:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: mysql:5.7
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: example
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
     volumes:
       - ./tmp/mysql:/var/lib/mysql
 
@@ -18,7 +18,7 @@ services:
     ports:
       - 8080:80
     environment:
-      WORDPRESS_DB_PASSWORD: example
+      WORDPRESS_DB_PASSWORD: ${DB_PASSWORD}
     volumes:
       - wordpress:/var/www/html
 
@@ -27,7 +27,7 @@ services:
       - wordpress
     image: wordpress:cli
     environment:
-      WORDPRESS_DB_PASSWORD: example
+      WORDPRESS_DB_PASSWORD: ${DB_PASSWORD}
     volumes:
       - wordpress:/var/www/html
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -1,5 +1,7 @@
 # How to roll with Docker
 
+⚠️ This doc is still in progress!
+
 ## Locally (or CI)
 
 1.  Make sure the project runs on your local (= everything compiled, etc)
@@ -22,7 +24,7 @@
     * Sometimes it says it works, but image pull still fails
     * If that happens, try: `gcloud docker -a`
 2.  `[sudo] docker pull eu.gcr.io/duodecim-203606/duodecim-ebmedss` should now work
-3.  Start the whole thing with: `[sudo] docker-compose up -d`
+3.  Start the whole thing with: `[sudo] docker-compose -f docker-compose.prod.yml up -d`
 
 # How to use Docker
 
@@ -30,7 +32,7 @@
 
 `docker-compose run --rm wp-cli`
 
-Recommend doing this: alias wpd='docker-compose run --rm wp-cli'
+Recommend doing this: `alias wpd='docker-compose run --rm wp-cli'`
 Then use it with 'wpd' as you would normally with 'wp', e.g. "wpd user list"
 
 ## First time setup

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -1,0 +1,37 @@
+# Development
+
+Modify `htdocs/wp-content/themes/theme-skeletor/config.json` and set the site URL for Browsersync. Use the same URL you're running the WordPress on.
+
+Install development dependencies by running `npm install`.
+
+Finally run `npm run dev` to run build and Browsersync. The browser tab doesn't open automatically so just head to the `https://localhost:3000`. If you have something running on 3000, it will automatically try the next port, such as 3001.
+
+## Webfonts
+
+Webfonts are a bit tricky. `@font-face` works, but a bit different than you might expect. Basically, you're going to want to put your declarations to `app/styl/typography.styl`, and your fonts in `app/fonts/`, but you're going to refer to them as if they were in `app/styl/fonts`:
+
+```
+@font-face {
+  font-family: 'FontName';
+  src: url('./fonts/FontName/weight.woff')
+    format('woff');
+  font-weight: 700;
+}
+```
+
+### Tagging
+
+Composer won't use the master branch. Instead it uses tags. When you have something you want to deploy, commit your changes, and then run `git tag [your-version-here]`. If you are unsure what version number to use for the tag, run `git tag` to see a list of tags. Semantic versioning is just about the only versioning that makes sense, so use that. Basics of semantic versioning: **major**.**minor**.**patch**
+
+Increment the _major_ number if you introduce breaking changes. Doesn't really happen in themes.
+Increment the _minor_ number if you add features.
+Increment the _patch_ number if you fix bugs.
+
+So if the current version is 0.3.1, and you add a new feature, run `git tag 0.4`.
+To make the tag available for Composer, run `git push origin 0.4`.
+
+Then when you run `composer update` on projects that have required this theme, you should see output similar to this:
+
+```
+- Updating redandblue/theme-skeleton (0.1 => 0.1.1):  Checking out 7e4615cfd8
+```


### PR DESCRIPTION
This repository can now be used without Skeletor with Docker, and Docker can now also be used for development. Updated READMEs and other documentation as well.